### PR TITLE
Add markdown support to chat bubbles

### DIFF
--- a/Spixi/Resources/Raw/html/css/spixiui-dark.css
+++ b/Spixi/Resources/Raw/html/css/spixiui-dark.css
@@ -5627,3 +5627,38 @@ input.create-account-username[type="password"] {
 .chat-message .markdown-content blockquote code {
     background: var(--colors-surface-04);
 }
+
+/* Markdown Tables */
+.markdown-table {
+    overflow-x: auto;
+    margin: 8px 0;
+}
+
+.markdown-table table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 9pt;
+}
+
+.markdown-table th,
+.markdown-table td {
+    border: 1px solid var(--colors-outline-02);
+    padding: 6px 10px;
+    text-align: left;
+    word-break: normal;
+    white-space: nowrap;
+}
+
+.markdown-table th {
+    background: var(--colors-surface-05);
+    font-weight: 600;
+    color: var(--colors-text-01);
+}
+
+.markdown-table tr:nth-child(even) {
+    background: var(--colors-surface-02);
+}
+
+.markdown-table tr:hover {
+    background: var(--colors-surface-03);
+}

--- a/Spixi/Resources/Raw/html/css/spixiui-dark.css
+++ b/Spixi/Resources/Raw/html/css/spixiui-dark.css
@@ -5537,3 +5537,93 @@ input.create-account-username[type="password"] {
     padding: 10px;
     font-size: 13px;
 }
+
+/* ======================================== */
+/* MARKDOWN SUPPORT IN CHAT BUBBLES         */
+/* ======================================== */
+
+.chat-message .markdown-content {
+    word-break: break-word;
+}
+
+.chat-message .markdown-content h1,
+.chat-message .markdown-content h2,
+.chat-message .markdown-content h3 {
+    margin: 8px 0 4px 0;
+    font-size: 1.1em;
+    color: var(--colors-text-01);
+}
+
+.chat-message .markdown-content h1 { font-size: 1.3em; }
+.chat-message .markdown-content h2 { font-size: 1.2em; }
+
+.chat-message .markdown-content p {
+    margin: 4px 0;
+}
+
+.chat-message .markdown-content code {
+    background: var(--colors-surface-05);
+    padding: 2px 6px;
+    border-radius: 4px;
+    font-family: 'Courier New', monospace;
+    color: var(--colors-text-link-02);
+}
+
+.chat-message .markdown-content pre {
+    background: var(--colors-surface-05);
+    padding: 8px 12px;
+    border-radius: 6px;
+    overflow-x: auto;
+    margin: 6px 0;
+    font-family: 'Courier New', monospace;
+}
+
+.chat-message .markdown-content pre code {
+    background: none;
+    padding: 0;
+    color: var(--colors-text-01);
+}
+
+.chat-message .markdown-content blockquote {
+    border-left: 3px solid var(--colors-text-action);
+    margin: 6px 0;
+    padding-left: 12px;
+    color: var(--colors-text-02);
+    font-style: italic;
+}
+
+.chat-message .markdown-content ul,
+.chat-message .markdown-content ol {
+    margin: 4px 0;
+    padding-left: 20px;
+}
+
+.chat-message .markdown-content li {
+    margin: 2px 0;
+}
+
+.chat-message .markdown-content hr {
+    border: none;
+    border-top: 1px solid var(--colors-text-03);
+    margin: 8px 0;
+}
+
+.chat-message .markdown-content del {
+    text-decoration: line-through;
+    color: var(--colors-text-02);
+}
+
+.chat-message .markdown-content strong {
+    font-weight: bold;
+    color: var(--colors-text-01);
+}
+
+.chat-message .markdown-content em {
+    font-style: italic;
+}
+
+/* Inline code in lists and quotes */
+.chat-message .markdown-content li code,
+.chat-message .markdown-content blockquote code {
+    background: var(--colors-surface-04);
+}

--- a/Spixi/Resources/Raw/html/css/spixiui-light.css
+++ b/Spixi/Resources/Raw/html/css/spixiui-light.css
@@ -5514,3 +5514,93 @@ input.create-account-username[type="password"] {
     padding: 10px;
     font-size: 13px;
 }
+
+/* ======================================== */
+/* MARKDOWN SUPPORT IN CHAT BUBBLES (LIGHT) */
+/* ======================================== */
+
+.chat-message .markdown-content {
+    word-break: break-word;
+}
+
+.chat-message .markdown-content h1,
+.chat-message .markdown-content h2,
+.chat-message .markdown-content h3 {
+    margin: 8px 0 4px 0;
+    font-size: 1.1em;
+    color: #1a1a1a;
+}
+
+.chat-message .markdown-content h1 { font-size: 1.3em; }
+.chat-message .markdown-content h2 { font-size: 1.2em; }
+
+.chat-message .markdown-content p {
+    margin: 4px 0;
+}
+
+.chat-message .markdown-content code {
+    background: #f0f0f0;
+    padding: 2px 6px;
+    border-radius: 4px;
+    font-family: 'Courier New', monospace;
+    color: #d94e3b;
+}
+
+.chat-message .markdown-content pre {
+    background: #f5f5f5;
+    padding: 8px 12px;
+    border-radius: 6px;
+    overflow-x: auto;
+    margin: 6px 0;
+    font-family: 'Courier New', monospace;
+}
+
+.chat-message .markdown-content pre code {
+    background: none;
+    padding: 0;
+    color: #333;
+}
+
+.chat-message .markdown-content blockquote {
+    border-left: 3px solid #6AB2FB;
+    margin: 6px 0;
+    padding-left: 12px;
+    color: #666;
+    font-style: italic;
+}
+
+.chat-message .markdown-content ul,
+.chat-message .markdown-content ol {
+    margin: 4px 0;
+    padding-left: 20px;
+}
+
+.chat-message .markdown-content li {
+    margin: 2px 0;
+}
+
+.chat-message .markdown-content hr {
+    border: none;
+    border-top: 1px solid #e0e0e0;
+    margin: 8px 0;
+}
+
+.chat-message .markdown-content del {
+    text-decoration: line-through;
+    color: #999;
+}
+
+.chat-message .markdown-content strong {
+    font-weight: bold;
+    color: #1a1a1a;
+}
+
+.chat-message .markdown-content em {
+    font-style: italic;
+}
+
+/* Inline code in lists and quotes */
+.chat-message .markdown-content li code,
+.chat-message .markdown-content blockquote code {
+    background: #e8e8e8;
+}

--- a/Spixi/Resources/Raw/html/css/spixiui-light.css
+++ b/Spixi/Resources/Raw/html/css/spixiui-light.css
@@ -5604,3 +5604,38 @@ input.create-account-username[type="password"] {
 .chat-message .markdown-content blockquote code {
     background: #e8e8e8;
 }
+
+/* Markdown Tables */
+.markdown-table {
+    overflow-x: auto;
+    margin: 8px 0;
+}
+
+.markdown-table table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 9pt;
+}
+
+.markdown-table th,
+.markdown-table td {
+    border: 1px solid #ddd;
+    padding: 6px 10px;
+    text-align: left;
+    word-break: normal;
+    white-space: nowrap;
+}
+
+.markdown-table th {
+    background: #f5f5f5;
+    font-weight: 600;
+    color: #1a1a1a;
+}
+
+.markdown-table tr:nth-child(even) {
+    background: #fafafa;
+}
+
+.markdown-table tr:hover {
+    background: #f0f0f0;
+}

--- a/Spixi/Resources/Raw/html/js/chat.js
+++ b/Spixi/Resources/Raw/html/js/chat.js
@@ -644,7 +644,9 @@ function simpleMarkdownParse(text) {
     });
     
     // Inline code (single backtick)
-    result = result.replace(/`([^`]+)`/g, '<code>' + escapeParameter('$1') + '</code>');
+    result = result.replace(/`([^`]+)`/g, function(match, code) {
+        return '<code>' + escapeParameter(code) + '</code>';
+    });
     
     // Strikethrough: ~~text~~
     result = result.replace(/~~(.+?)~~/g, '<del>$1</del>');

--- a/Spixi/Resources/Raw/html/js/chat.js
+++ b/Spixi/Resources/Raw/html/js/chat.js
@@ -623,12 +623,84 @@ function onExternalLink(e, url) {
     return false;
 }
 
+// Markdown configuration - customize as needed
+const MARKED_OPTIONS = {
+    breaks: true,           // Convert \n to <br>
+    gfm: true,              // GitHub Flavored Markdown
+    headerIds: false,       // Don't add IDs to headers (not needed in chat)
+    mangle: false           // Don't autodetect emails/handles
+};
+
+// Simple markdown parser for common formatting (no external dependencies required)
+function simpleMarkdownParse(text) {
+    // Escape HTML first to prevent injection
+    let result = text;
+    
+    // Code blocks (triple backticks) - protect from other parsing
+    const codeBlocks = [];
+    result = result.replace(/```([\s\S]*?)```/g, function(match, code) {
+        codeBlocks.push('<pre><code>' + escapeParameter(code.trim()) + '</code></pre>');
+        return '%%CODE_BLOCK_' + (codeBlocks.length - 1) + '%%';
+    });
+    
+    // Inline code (single backtick)
+    result = result.replace(/`([^`]+)`/g, '<code>' + escapeParameter('$1') + '</code>');
+    
+    // Strikethrough: ~~text~~
+    result = result.replace(/~~(.+?)~~/g, '<del>$1</del>');
+    
+    // Bold: **text** or __text__
+    result = result.replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>');
+    result = result.replace(/__(.+?)__/g, '<strong>$1</strong>');
+    
+    // Italic: *text* or _word_ (careful with underscores in words)
+    result = result.replace(/\*(\S.*?\S)\*/g, '<em>$1</em>');
+    result = result.replace(/(?<![a-zA-Z0-9])_(\w+)_(?![a-zA-Z0-9])/g, '<em>$1</em>');
+    
+    // Blockquotes: > text
+    result = result.replace(/^&gt; (.+)$/gm, '<blockquote>$1</blockquote>');
+    
+    // Lists (simple - just bullet points)
+    result = result.replace(/^- (.+)$/gm, '<li>$1</li>');
+    result = result.replace(/(<\/li>\n?<li>)+/g, function(m) {
+        return '<ul>' + m + '</ul>';
+    });
+    
+    // Horizontal rule: --- or ***
+    result = result.replace(/^---$/gm, '<hr>');
+    result = result.replace(/^\*\*\*$/gm, '<hr>');
+    
+    // Headers (simple - just # through ###)
+    result = result.replace(/^### (.+)$/gm, '<h3>$1</h3>');
+    result = result.replace(/^## (.+)$/gm, '<h2>$1</h2>');
+    result = result.replace(/^# (.+)$/gm, '<h1>$1</h1>');
+    
+    // Restore code blocks
+    for (let i = 0; i < codeBlocks.length; i++) {
+        result = result.replace('%%CODE_BLOCK_' + i + '%%', codeBlocks[i]);
+    }
+    
+    // Convert remaining newlines to <br> (but not inside pre/code blocks)
+    result = result.replace(/\n/g, '<br>');
+    
+    return result;
+}
+
 function parseMessageText(text) {
     try {
-        text = linkify(text);
+        // First escape HTML to prevent injection
+        let html = escapeParameter(text);
+        
+        // Parse markdown formatting
+        html = simpleMarkdownParse(html);
+        
+        // Then linkify URLs (handles plain URLs not converted by markdown)
+        html = linkify(html);
     } catch (e) {
+        // Fallback to plain text with line breaks on error
+        html = escapeParameter(text).replace(/\n/g, "<br>");
     }
-    return text;
+    return html;
 }
 
 let lastInsertedDate = null;

--- a/Spixi/Resources/Raw/html/js/chat.js
+++ b/Spixi/Resources/Raw/html/js/chat.js
@@ -633,21 +633,42 @@ const MARKED_OPTIONS = {
 
 // Simple markdown parser for common formatting (no external dependencies required)
 function simpleMarkdownParse(text) {
-    // Escape HTML first to prevent injection
+    // Extract and protect code blocks to prevent parsing inside them
+    const blocks = [];
     let result = text;
     
-    // Code blocks (triple backticks) - protect from other parsing
-    const codeBlocks = [];
-    result = result.replace(/```([\s\S]*?)```/g, function(match, code) {
-        codeBlocks.push('<pre><code>' + escapeParameter(code.trim()) + '</code></pre>');
-        return '%%CODE_BLOCK_' + (codeBlocks.length - 1) + '%%';
+    // Protect triple backtick code blocks
+    result = result.replace(/```([\s\S]*?)```/g, (m, c) => {
+        blocks.push('<pre><code>' + escapeParameter(c.trim()) + '</code></pre>');
+        return '\x00BLOCK_' + (blocks.length - 1) + '\x00';
     });
     
-    // Inline code (single backtick)
-    result = result.replace(/`([^`]+)`/g, function(match, code) {
-        return '<code>' + escapeParameter(code) + '</code>';
+    // Protect inline code
+    result = result.replace(/`([^`]+)`/g, (m, c) => {
+        blocks.push('<code>' + escapeParameter(c) + '</code>');
+        return '\x00BLOCK_' + (blocks.length - 1) + '\x00';
     });
     
+    // Parse markdown tables (before escaping)
+    result = parseMarkdownTables(result);
+    
+    // Escape HTML in non-protected parts
+    let tempResult = '';
+    let lastIndex = 0;
+    const blockRegex = /\x00BLOCK_(\d+)\x00/g;
+    let match;
+    while ((match = blockRegex.exec(result)) !== null) {
+        // Escape text before this block
+        tempResult += escapeParameter(result.substring(lastIndex, match.index));
+        // Add the protected block as-is
+        tempResult += blocks[parseInt(match[1])];
+        lastIndex = match.index + match[0].length;
+    }
+    // Escape remaining text
+    tempResult += escapeParameter(result.substring(lastIndex));
+    result = tempResult;
+    
+    // Apply other markdown formatting
     // Strikethrough: ~~text~~
     result = result.replace(/~~(.+?)~~/g, '<del>$1</del>');
     
@@ -655,17 +676,242 @@ function simpleMarkdownParse(text) {
     result = result.replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>');
     result = result.replace(/__(.+?)__/g, '<strong>$1</strong>');
     
-    // Italic: *text* or _word_ (careful with underscores in words)
+    // Italic: *text* or _word_
     result = result.replace(/\*(\S.*?\S)\*/g, '<em>$1</em>');
     result = result.replace(/(?<![a-zA-Z0-9])_(\w+)_(?![a-zA-Z0-9])/g, '<em>$1</em>');
     
-    // Blockquotes: > text
+    // Blockquotes: > text (already escaped as &gt;)
     result = result.replace(/^&gt; (.+)$/gm, '<blockquote>$1</blockquote>');
     
-    // Lists (simple - just bullet points)
+    // Lists
     result = result.replace(/^- (.+)$/gm, '<li>$1</li>');
     result = result.replace(/(<\/li>\n?<li>)+/g, function(m) {
         return '<ul>' + m + '</ul>';
+    });
+    
+    // Horizontal rule
+    result = result.replace(/^---$/gm, '<hr>');
+    result = result.replace(/^\*\*\*$/gm, '<hr>');
+    
+    // Headers
+    result = result.replace(/^### (.+)$/gm, '<h3>$1</h3>');
+    result = result.replace(/^## (.+)$/gm, '<h2>$1</h2>');
+    result = result.replace(/^# (.+)$/gm, '<h1>$1</h1>');
+    
+    // Convert newlines to <br>
+    result = result.replace(/\n/g, '<br>');
+    
+    return result;
+}
+    result = result.replace(/^## (.+)$/gm, '<h2>$1</h2>');
+    result = result.replace(/^# (.+)$/gm, '<h1>$1</h1>');
+    
+    // Convert newlines to <br>
+    result = result.replace(/\n/g, '<br>');
+    
+    return result;
+}
+
+// Parse markdown tables
+function parseMarkdownTables(text) {
+    const lines = text.split('\n');
+    let inTable = false;
+    let tableHtml = '';
+    let tableRows = [];
+    let output = [];
+    
+    for (let i = 0; i < lines.length; i++) {
+        const line = lines[i];
+        
+        if (/^\|(.+)\|$/.test(line)) {
+            // This is a table row
+            if (!inTable) {
+                inTable = true;
+                tableRows = [];
+            }
+            
+            const cells = line.match(/[^|]+/g).map(c => c.trim());
+            const isSeparator = cells.length > 0 && cells.every(cell => /^[-:]+$/.test(cell));
+            
+            if (isSeparator) {
+                // Separator row - build table header
+                if (tableRows.length > 0) {
+                    output.push(buildTableHtml(tableRows, cells));
+                }
+                tableRows = [];
+            } else {
+                tableRows.push(cells);
+            }
+        } else {
+            // Non-table row - flush any pending table
+            if (inTable && tableRows.length > 0) {
+                output.push(buildTableHtml(tableRows, null));
+                tableRows = [];
+                inTable = false;
+            }
+            output.push(line);
+        }
+    }
+    
+    // Flush any remaining table
+    if (inTable && tableRows.length > 0) {
+        output.push(buildTableHtml(tableRows, null));
+    }
+    
+    return output.join('\n');
+}
+
+function buildTableHtml(rows, headerAlignments) {
+    if (rows.length === 0) return '';
+    
+    let html = '<div class="markdown-table"><table>';
+    
+    // Build header row
+    if (rows.length > 0) {
+        const headerRow = rows[0];
+        html += '<thead><tr>';
+        for (let j = 0; j < headerRow.length; j++) {
+            let align = 'left';
+            if (headerAlignments && headerAlignments[j]) {
+                if (/^:-:/.test(headerAlignments[j])) align = 'center';
+                else if (/^-:/.test(headerAlignments[j])) align = 'right';
+                else if (/^:/ .test(headerAlignments[j])) align = 'left';
+            }
+            html += '<th style="text-align:' + align + '">' + headerRow[j] + '</th>';
+        }
+        html += '</tr></thead>';
+    }
+    
+    // Build body rows
+    if (rows.length > 1) {
+        html += '<tbody>';
+        for (let i = 1; i < rows.length; i++) {
+            const row = rows[i];
+            html += '<tr>';
+            for (let j = 0; j < row.length; j++) {
+                html += '<td>' + row[j] + '</td>';
+            }
+            html += '</tr>';
+        }
+        html += '</tbody>';
+    } else if (headerAlignments && rows.length === 1) {
+        // Only header and separator, no body rows yet
+        const headerRow = rows[0];
+        html += '<tbody>';
+        html += '<tr>';
+        for (let j = 0; j < headerRow.length; j++) {
+            let align = 'left';
+            if (headerAlignments[j]) {
+                if (/^:-:/.test(headerAlignments[j])) align = 'center';
+                else if (/^-:/.test(headerAlignments[j])) align = 'right';
+                else if (/^:/ .test(headerAlignments[j])) align = 'left';
+            }
+            html += '<th style="text-align:' + align + '">' + headerRow[j] + '</th>';
+        }
+        html += '</tr>';
+        html += '</tbody>';
+    } else if (rows.length === 1) {
+        // Single row without separator
+        const headerRow = rows[0];
+        html += '<tbody><tr>';
+        for (let j = 0; j < headerRow.length; j++) {
+            html += '<td>' + headerRow[j] + '</td>';
+        }
+        html += '</tr></tbody>';
+    }
+    
+    html += '</table></div>';
+    return html;
+}
+
+// Simple markdown parser for common formatting (no external dependencies required) - OLD VERSION, REMOVED
+    
+    // Markdown Tables
+    const tableMatches = result.match(/^\|(.+)\|$/gm);
+    if (tableMatches && tableMatches.length >= 3) {
+        let tableHtml = '';
+        let inTable = false;
+        let tableRows = [];
+        
+        const lines = result.split('\n');
+        for (let i = 0; i < lines.length; i++) {
+            const line = lines[i];
+            if (/^\|(.+)\|$/.test(line)) {
+                if (!inTable) {
+                    inTable = true;
+                    tableRows = [];
+                }
+                
+                // Check if this is a separator row (|---|---|)
+                const cells = line.match(/[^|]+/g).map(cell => cell.trim());
+                const isSeparator = cells.every(cell => /^[-:]+$/.test(cell));
+                
+                if (isSeparator && tableRows.length > 0) {
+                    // Build thead
+                    tableHtml += '<div class="markdown-table"><table><thead><tr>';
+                    for (const cell of cells.slice(0, tableRows[0].length)) {
+                        const align = /^-:/.test(cell) ? 'right' : /^:-/:^:-.-:/g.test(cell) ? 'center' : 'left';
+                        tableHtml += `<th style="text-align:${align}"></th>`;
+                    }
+                    tableHtml += '</tr></thead><tbody>';
+                } else if (!isSeparator) {
+                    tableRows.push(cells);
+                }
+            } else if (inTable && line.trim() === '') {
+                // End of table
+                inTable = false;
+            }
+        }
+    }
+    
+    // Parse tables (simplified approach)
+    const tableRegex = /(\|.+\|(\n\|.+(\|.+)*\n)?(\n\|-+[\s:|:-]+\|)(\n\|.+\|)*)/g;
+    result = result.replace(tableRegex, function(match) {
+        const rows = match.trim().split('\n');
+        if (rows.length < 3) return match; // Not a valid table
+        
+        let html = '<div class="markdown-table"><table>';
+        let isHeaderParsed = false;
+        
+        for (let i = 0; i < rows.length; i++) {
+            const row = rows[i];
+            if (/^\|-+[\s:|:-]+\|$/.test(row)) {
+                // Skip separator line, but we're now past header
+                isHeaderParsed = true;
+                continue;
+            }
+            
+            const cells = row.match(/[^|]+/g) || [];
+            const cellContents = cells.map(cell => cell.trim()).filter(c => c);
+            
+            if (cellContents.length === 0) continue;
+            
+            if (!isHeaderParsed) {
+                // Header row
+                html += '<thead><tr>';
+                for (const content of cellContents) {
+                    html += `<th>${content}</th>`;
+                }
+                html += '</tr></thead>'; 
+                isHeaderParsed = true; // Mark header as parsed for next iteration
+            } else {
+                // Body row  
+                if (!html.includes('<tbody>')) {
+                    html += '<tbody>';
+                }
+                html += '<tr>';
+                for (const content of cellContents) {
+                    html += `<td>${content}</td>`;
+                }
+                html += '</tr>';
+            }
+        }
+        
+        if (html.includes('<tbody>')) {
+            html += '</tbody>';
+        }
+        html += '</table></div>';
+        return html;
     });
     
     // Horizontal rule: --- or ***

--- a/Spixi/Resources/Raw/html/js/chat.js
+++ b/Spixi/Resources/Raw/html/js/chat.js
@@ -703,14 +703,6 @@ function simpleMarkdownParse(text) {
     
     return result;
 }
-    result = result.replace(/^## (.+)$/gm, '<h2>$1</h2>');
-    result = result.replace(/^# (.+)$/gm, '<h1>$1</h1>');
-    
-    // Convert newlines to <br>
-    result = result.replace(/\n/g, '<br>');
-    
-    return result;
-}
 
 // Parse markdown tables
 function parseMarkdownTables(text) {
@@ -822,116 +814,6 @@ function buildTableHtml(rows, headerAlignments) {
     
     html += '</table></div>';
     return html;
-}
-
-// Simple markdown parser for common formatting (no external dependencies required) - OLD VERSION, REMOVED
-    
-    // Markdown Tables
-    const tableMatches = result.match(/^\|(.+)\|$/gm);
-    if (tableMatches && tableMatches.length >= 3) {
-        let tableHtml = '';
-        let inTable = false;
-        let tableRows = [];
-        
-        const lines = result.split('\n');
-        for (let i = 0; i < lines.length; i++) {
-            const line = lines[i];
-            if (/^\|(.+)\|$/.test(line)) {
-                if (!inTable) {
-                    inTable = true;
-                    tableRows = [];
-                }
-                
-                // Check if this is a separator row (|---|---|)
-                const cells = line.match(/[^|]+/g).map(cell => cell.trim());
-                const isSeparator = cells.every(cell => /^[-:]+$/.test(cell));
-                
-                if (isSeparator && tableRows.length > 0) {
-                    // Build thead
-                    tableHtml += '<div class="markdown-table"><table><thead><tr>';
-                    for (const cell of cells.slice(0, tableRows[0].length)) {
-                        const align = /^-:/.test(cell) ? 'right' : /^:-/:^:-.-:/g.test(cell) ? 'center' : 'left';
-                        tableHtml += `<th style="text-align:${align}"></th>`;
-                    }
-                    tableHtml += '</tr></thead><tbody>';
-                } else if (!isSeparator) {
-                    tableRows.push(cells);
-                }
-            } else if (inTable && line.trim() === '') {
-                // End of table
-                inTable = false;
-            }
-        }
-    }
-    
-    // Parse tables (simplified approach)
-    const tableRegex = /(\|.+\|(\n\|.+(\|.+)*\n)?(\n\|-+[\s:|:-]+\|)(\n\|.+\|)*)/g;
-    result = result.replace(tableRegex, function(match) {
-        const rows = match.trim().split('\n');
-        if (rows.length < 3) return match; // Not a valid table
-        
-        let html = '<div class="markdown-table"><table>';
-        let isHeaderParsed = false;
-        
-        for (let i = 0; i < rows.length; i++) {
-            const row = rows[i];
-            if (/^\|-+[\s:|:-]+\|$/.test(row)) {
-                // Skip separator line, but we're now past header
-                isHeaderParsed = true;
-                continue;
-            }
-            
-            const cells = row.match(/[^|]+/g) || [];
-            const cellContents = cells.map(cell => cell.trim()).filter(c => c);
-            
-            if (cellContents.length === 0) continue;
-            
-            if (!isHeaderParsed) {
-                // Header row
-                html += '<thead><tr>';
-                for (const content of cellContents) {
-                    html += `<th>${content}</th>`;
-                }
-                html += '</tr></thead>'; 
-                isHeaderParsed = true; // Mark header as parsed for next iteration
-            } else {
-                // Body row  
-                if (!html.includes('<tbody>')) {
-                    html += '<tbody>';
-                }
-                html += '<tr>';
-                for (const content of cellContents) {
-                    html += `<td>${content}</td>`;
-                }
-                html += '</tr>';
-            }
-        }
-        
-        if (html.includes('<tbody>')) {
-            html += '</tbody>';
-        }
-        html += '</table></div>';
-        return html;
-    });
-    
-    // Horizontal rule: --- or ***
-    result = result.replace(/^---$/gm, '<hr>');
-    result = result.replace(/^\*\*\*$/gm, '<hr>');
-    
-    // Headers (simple - just # through ###)
-    result = result.replace(/^### (.+)$/gm, '<h3>$1</h3>');
-    result = result.replace(/^## (.+)$/gm, '<h2>$1</h2>');
-    result = result.replace(/^# (.+)$/gm, '<h1>$1</h1>');
-    
-    // Restore code blocks
-    for (let i = 0; i < codeBlocks.length; i++) {
-        result = result.replace('%%CODE_BLOCK_' + i + '%%', codeBlocks[i]);
-    }
-    
-    // Convert remaining newlines to <br> (but not inside pre/code blocks)
-    result = result.replace(/\n/g, '<br>');
-    
-    return result;
 }
 
 function parseMessageText(text) {

--- a/Spixi/Resources/Raw/html/js/chat.js
+++ b/Spixi/Resources/Raw/html/js/chat.js
@@ -689,9 +689,10 @@ function simpleMarkdownParse(text) {
 }
 
 function parseMessageText(text) {
+    let html;
     try {
         // First escape HTML to prevent injection
-        let html = escapeParameter(text);
+        html = escapeParameter(text);
         
         // Parse markdown formatting
         html = simpleMarkdownParse(html);

--- a/Spixi/Resources/Raw/html/js/chat.js.patch
+++ b/Spixi/Resources/Raw/html/js/chat.js.patch
@@ -1,0 +1,92 @@
+--- a/Spixi/Resources/Raw/html/js/chat.js
++++ b/Spixi/Resources/Raw/html/js/chat.js
+@@ -536,12 +536,78 @@ function onExternalLink(e, url) {
+     e.stopPropagation();
+     return false;
+ }
+
++// Markdown configuration - customize as needed
++const MARKED_OPTIONS = {
++    breaks: true,           // Convert \n to <br>
++    gfm: true,              // GitHub Flavored Markdown
++    headerIds: false,       // Don't add IDs to headers (not needed in chat)
++    mangle: false           // Don't autodetect emails/handles
++};
++
++// Simple markdown parser for common formatting (no external dependencies required)
++function simpleMarkdownParse(text) {
++    // Escape HTML first to prevent injection
++    let result = text;
++    
++    // Code blocks (triple backticks) - protect from other parsing
++    const codeBlocks = [];
++    result = result.replace(/```([\s\S]*?)```/g, function(match, code) {
++        codeBlocks.push('<pre><code>' + escapeParameter(code.trim()) + '</code></pre>');
++        return '%%CODE_BLOCK_' + (codeBlocks.length - 1) + '%%';
++    });
++    
++    // Inline code (single backtick)
++    result = result.replace(/`([^`]+)`/g, '<code>' + escapeParameter('$1') + '</code>');
++    
++    // Strikethrough: ~~text~~
++    result = result.replace(/~~(.+?)~~/g, '<del>$1</del>');
++    
++    // Bold: **text** or __text__
++    result = result.replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>');
++    result = result.replace(/__(.+?)__/g, '<strong>$1</strong>');
++    
++    // Italic: *text* or _word_ (careful with underscores in words)
++    result = result.replace(/\*(\S.*?\S)\*/g, '<em>$1</em>');
++    result = result.replace(/(?<![a-zA-Z0-9])_(\w+)_(?![a-zA-Z0-9])/g, '<em>$1</em>');
++    
++    // Blockquotes: > text
++    result = result.replace(/^&gt; (.+)$/gm, '<blockquote>$1</blockquote>');
++    
++    // Lists (simple - just bullet points)
++    result = result.replace(/^- (.+)$/gm, '<li>$1</li>');
++    result = result.replace(/(<\/li>\n?<li>)+/g, function(m) {
++        return '<ul>' + m + '</ul>';
++    });
++    
++    // Horizontal rule: --- or ***
++    result = result.replace(/^---$/gm, '<hr>');
++    result = result.replace(/^\*\*\*$/gm, '<hr>');
++    
++    // Headers (simple - just # through ###)
++    result = result.replace(/^### (.+)$/gm, '<h3>$1</h3>');
++    result = result.replace(/^## (.+)$/gm, '<h2>$1</h2>');
++    result = result.replace(/^# (.+)$/gm, '<h1>$1</h1>');
++    
++    // Restore code blocks
++    for (let i = 0; i < codeBlocks.length; i++) {
++        result = result.replace('%%CODE_BLOCK_' + i + '%%', codeBlocks[i]);
++    }
++    
++    // Convert remaining newlines to <br> (but not inside pre/code blocks)
++    // This is a simplification - for full accuracy, parse block-level elements properly
++    result = result.replace(/(?<!><\/pre>)\n/g, '<br>');
++    
++    return result;
++}
++
+ function parseMessageText(text) {
+     try {
+-        text = linkify(text);
++        // First escape HTML to prevent injection
++        let html = escapeParameter(text);
++        
++        // Parse markdown formatting
++        html = simpleMarkdownParse(html);
++        
++        // Then linkify URLs (handles plain URLs not converted by markdown)
++        html = linkify(html);
+     } catch (e) {
+-        console.error('Error parsing message text:', e);
++        // Fallback to plain text with line breaks on error
++        html = escapeParameter(text).replace(/\n/g, "<br>");
+     }
+-    return text;
++    return html;
+ }
+ 
+ let lastInsertedDate = null;

--- a/test-tables.html
+++ b/test-tables.html
@@ -1,0 +1,153 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Markdown Table Test</title>
+    <style>
+        body { font-family: Arial, sans-serif; padding: 20px; }
+        .markdown-table { overflow-x: auto; margin: 8px 0; }
+        .markdown-table table { width: 100%; border-collapse: collapse; font-size: 9pt; }
+        .markdown-table th, .markdown-table td { border: 1px solid #ddd; padding: 6px 10px; text-align: left; }
+        .markdown-table th { background: #f5f5f5; font-weight: 600; }
+        .markdown-table tr:nth-child(even) { background: #fafafa; }
+    </style>
+</head>
+<body>
+    <h1>Markdown Table Parser Test</h1>
+    
+    <div id="output"></div>
+    
+    <script>
+        function escapeParameter(text) {
+            return text.replace(/&/g, '&amp;')
+                      .replace(/</g, '&lt;')
+                      .replace(/>/g, '&gt;')
+                      .replace(/"/g, '&quot;')
+                      .replace(/'/g, '&#039;');
+        }
+
+        function parseMarkdownTables(text) {
+            const lines = text.split('\n');
+            let inTable = false;
+            let tableRows = [];
+            let output = [];
+            
+            for (let i = 0; i < lines.length; i++) {
+                const line = lines[i];
+                
+                if (/^\|(.+)\|$/.test(line)) {
+                    if (!inTable) {
+                        inTable = true;
+                        tableRows = [];
+                    }
+                    
+                    const cells = line.match(/[^|]+/g).map(c => c.trim());
+                    const isSeparator = cells.length > 0 && cells.every(cell => /^[-:]+$/.test(cell));
+                    
+                    if (isSeparator) {
+                        if (tableRows.length > 0) {
+                            output.push(buildTableHtml(tableRows, cells));
+                        }
+                        tableRows = [];
+                    } else {
+                        tableRows.push(cells);
+                    }
+                } else {
+                    if (inTable && tableRows.length > 0) {
+                        output.push(buildTableHtml(tableRows, null));
+                        tableRows = [];
+                        inTable = false;
+                    }
+                    output.push(line);
+                }
+            }
+            
+            if (inTable && tableRows.length > 0) {
+                output.push(buildTableHtml(tableRows, null));
+            }
+            
+            return output.join('\n');
+        }
+
+        function buildTableHtml(rows, headerAlignments) {
+            if (rows.length === 0) return '';
+            
+            let html = '<div class="markdown-table"><table>';
+            
+            if (rows.length > 0) {
+                const headerRow = rows[0];
+                html += '<thead><tr>';
+                for (let j = 0; j < headerRow.length; j++) {
+                    let align = 'left';
+                    if (headerAlignments && headerAlignments[j]) {
+                        if (/^:-:/.test(headerAlignments[j])) align = 'center';
+                        else if (/^-:/.test(headerAlignments[j])) align = 'right';
+                        else if (/^:(?=.*-)/.test(headerAlignments[j])) align = 'left';
+                    }
+                    html += '<th style="text-align:' + align + '">' + headerRow[j] + '</th>';
+                }
+                html += '</tr></thead>';
+            }
+            
+            if (rows.length > 1) {
+                html += '<tbody>';
+                for (let i = 1; i < rows.length; i++) {
+                    const row = rows[i];
+                    html += '<tr>';
+                    for (let j = 0; j < row.length; j++) {
+                        html += '<td>' + row[j] + '</td>';
+                    }
+                    html += '</tr>';
+                }
+                html += '</tbody>';
+            } else if (headerAlignments && rows.length === 1) {
+                const headerRow = rows[0];
+                html += '<tbody>';
+                html += '<tr>';
+                for (let j = 0; j < headerRow.length; j++) {
+                    let align = 'left';
+                    if (headerAlignments[j]) {
+                        if (/^:-:/.test(headerAlignments[j])) align = 'center';
+                        else if (/^-:/.test(headerAlignments[j])) align = 'right';
+                        else if (/^:(?=.*-)/.test(headerAlignments[j])) align = 'left';
+                    }
+                    html += '<th style="text-align:' + align + '">' + headerRow[j] + '</th>';
+                }
+                html += '</tr>';
+                html += '</tbody>';
+            } else if (rows.length === 1) {
+                const headerRow = rows[0];
+                html += '<tbody><tr>';
+                for (let j = 0; j < headerRow.length; j++) {
+                    html += '<td>' + headerRow[j] + '</td>';
+                }
+                html += '</tr></tbody>';
+            }
+            
+            html += '</table></div>';
+            return html;
+        }
+
+        // Test cases
+        const tests = [
+            `| Name | Age | City |
+|------|-----|------|
+| Alice | 30 | New York |
+| Bob | 25 | Los Angeles |`,
+            
+            `| Product | Price |
+|:---------|-------:|
+| Apple | $1.00 |
+| Banana | $0.50 |`
+        ];
+
+        tests.forEach((test, i) => {
+            const result = parseMarkdownTables(test);
+            document.getElementById('output').innerHTML += '<h2>Test ' + (i+1) + '</h2>';
+            document.getElementById('output').innerHTML += '<pre>' + escapeParameter(test) + '</pre>';
+            document.getElementById('output').innerHTML += '<hr><h3>Rendered:</h3>';
+            document.getElementById('output').innerHTML += result;
+            document.getElementById('output').innerHTML += '<br><br>';
+        });
+    </script>
+</body>
+</html>


### PR DESCRIPTION
- Implement simple Markdown parser for message formatting
- Support: bold, italic, strikethrough, inline code, code blocks
- Add headers (# ## ###), blockquotes, lists, horizontal rules
- Include CSS styles for both dark and light themes
- Auto-linkify URLs within markdown content
- Maintain XSS protection through HTML escaping before parsing

No external dependencies required - pure JavaScript implementation.